### PR TITLE
Adding file next route validation

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,5 +3,13 @@
     "next/core-web-vitals",
     "next",
     "plugin:prettier/recommended"
-  ]
+  ],
+  "rules": {
+    "prettier/prettier": [
+      "error",
+      {
+        "endOfLine": "auto"
+      }
+    ]
+  }
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,15 @@
 import { NextResponse, type NextRequest } from 'next/server';
 
+const isFileRegex = /(api|_next\/static|_next\/image|favicon\.ico|\/_next)/;
+
 export async function middleware(request: NextRequest) {
+  const url = request.nextUrl.clone();
   const response = NextResponse.next();
+
+  if (url.pathname.indexOf('.') != -1 || typeof window !== 'undefined')
+    return response;
+  if (isFileRegex.test(url.pathname)) return response;
+
   const token = request.cookies.get('token');
 
   if (!token || token.value !== process.env.SITE_COOKIE_KEY) {


### PR DESCRIPTION
## Describe
For each route, next.js always gets the static files, to avoid valid the token, I'm filtering static files like .next, .ico or favicon file and adding prettier rule in ESLint config.

## Pull-Request Checklist
- [x] Code is up-to-date with the ```master``` branch
- [x] ```npm run lint``` to apply prettier formatting
- [ ] Do we need to implement analytics?
- [ ] Documentation has been updated to reflect this change